### PR TITLE
basic react with basic webpack config

### DIFF
--- a/host-ui/.prettierrc
+++ b/host-ui/.prettierrc
@@ -1,0 +1,4 @@
+{
+"semi":false,
+"trailingComma": "es5"
+}

--- a/host-ui/package.json
+++ b/host-ui/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "host-ui",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "devDependencies": {
+    "@babel/core": "^7.15.5",
+    "@babel/preset-env": "^7.15.6",
+    "@babel/preset-react": "^7.14.5",
+    "babel-loader": "^8.2.2",
+    "html-webpack-plugin": "^5.3.2",
+    "prettier": "^2.4.1",
+    "webpack": "^5.56.0",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.3.0"
+  },
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  }
+}

--- a/host-ui/src/index.html
+++ b/host-ui/src/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <div id="app" />
+  </body>
+</html>

--- a/host-ui/src/index.js
+++ b/host-ui/src/index.js
@@ -1,0 +1,3 @@
+import React from "react"
+import ReactDOM from "react-dom"
+ReactDOM.render(<div>Hello world</div>, document.getElementById("app"))

--- a/host-ui/webpack.config.js
+++ b/host-ui/webpack.config.js
@@ -1,0 +1,24 @@
+const path = require("path")
+const HtmlWebpackPlugin = require("html-webpack-plugin")
+module.exports = {
+  entry: path.join(__dirname, "src", "index.js"),
+  plugins: [
+    new HtmlWebpackPlugin({
+      template: path.join(__dirname, "src", "index.html"),
+    }),
+  ],
+  module: {
+    rules: [
+      {
+        test: /\.?js$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader",
+          options: {
+            presets: ["@babel/preset-env", "@babel/preset-react"],
+          },
+        },
+      },
+    ],
+  },
+}


### PR DESCRIPTION
Boring / frustrating / infuriating stupid boilerplate
for web apps in 2021.

If you dont like "create-react-app" you live in pain.

This patch contains a code formatter setup (prettier),
dependencies for modern javascript and jsx to be transpiled (babel),
a development web server (webpack dev server), and a webpack config
that have the most basic render-react-inside-an-html setup.

Dont be like me, use the stupid cli to create boilerplates instead.